### PR TITLE
feat: support add api-secret in header

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,9 +4,10 @@ VITE_MIDJOURNEY_PROXY_URL='http://localhost:8080'
 
 # Example(mj.api-secret)
 # midjourney proxy api secret, see: https://github.com/novicezk/midjourney-proxy/wiki/%E9%85%8D%E7%BD%AE%E9%A1%B9
+# 避免所有人都可以访问后端的midjourney-proxy，所以需要配合后端api设置api-secret
 VITE_MIDJOURNEY_PROXY_API_SECRET='xxx'
 
 
-# WEB_LICENSE
-# web license, see:
-VITE_WEB_LICENSE='xxx'
+# # WEB_LICENSE
+# # web license, see:
+# VITE_WEB_LICENSE='xxx'

--- a/src/components/SingleMsg.tsx
+++ b/src/components/SingleMsg.tsx
@@ -94,7 +94,7 @@ export default ({ role, message, result, showRetry, onRetry ,clickAction,action,
                 src={uploadImages[0]}
                 alt=""
                 width={"300px"}
-                className={`mt-2 rounded-md`}
+                className={`mt-2 rounded-md select-none`}
               />
             </PhotoView>
           </div>

--- a/src/utils/fetchEnhance.ts
+++ b/src/utils/fetchEnhance.ts
@@ -10,24 +10,26 @@ export async function fetchPost(url = '', data = {}) {
   return response.json()
 }
 export async function fetchMJPost(url = '', data = {}) {
-    const response = await fetch('/mj-api'+url, {
-        method: 'POST',
-        headers: {
-            'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(data),
-    })
+    const response = await fetch("/mj-api" + url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "mj-api-secret": import.meta.env.VITE_MIDJOURNEY_PROXY_API_SECRET??'',
+      },
+      body: JSON.stringify(data),
+    });
     return response.json()
 }
 
 
 export async function fetchMJGet(url = '') {
-    const response = await fetch('/mj-api'+url, {
-        method: 'GET',
-        headers: {
-            'Content-Type': 'application/json',
-        },
-    })
+    const response = await fetch("/mj-api" + url, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        "mj-api-secret": import.meta.env.VITE_MIDJOURNEY_PROXY_API_SECRET ?? "",
+      },
+    });
     if (!response.ok) {
         throw new Error(response.statusText)
     }


### PR DESCRIPTION
<!-- 请务必在创建PR前，在右侧 Labels 选项中加上label的其中一个: [feature]、[fix]、[documentation]、[dependencies]、[test] 。以便于Actions自动生成Releases时自动对PR进行归类。-->
## 描述
支持在header传递`api-secret`,

避免所有人都可以访问后端的midjourney-proxy，所以需要配合后端api设置api-secret
 参见midjourney-proxy的`mj.api-secret` [解释说明](https://github.com/novicezk/midjourney-proxy/wiki/%E9%85%8D%E7%BD%AE%E9%A1%B9)


## 相关问题
- fix #9 

## 截图

![image](https://github.com/ConnectAI-E/MidJourney-Web/assets/50035229/befd0140-e945-4fb9-9c60-612948929f1a)


